### PR TITLE
Depend on libinotify on NetBSD

### DIFF
--- a/hinotify.cabal
+++ b/hinotify.cabal
@@ -34,7 +34,7 @@ library
     includes: sys/inotify.h
     hs-source-dirs: src
 
-    if os(freebsd) || os(openbsd)
+    if os(freebsd) || os(netbsd) || os(openbsd)
       extra-libraries: inotify
 
 test-suite test001


### PR DESCRIPTION
libinotify is an emulation layer that implements inotify on top of kqueue(2). See also #32.